### PR TITLE
Make clear what default db user is called

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To build Helical Insight Community Edition project you need
 *  Apache tomcat 7 or 8 should be installed.
 *  Use Mysql 5.7 or higher version.
 
- `NOTE: In case database is not accessed remotely then grant all priviledges to user.`
+ `NOTE: In case database is not accessed remotely then grant all priviledges to user (default called hiuser).`
 
 *  Database with name `hice` to be created in Mysql.
 

--- a/ansible-installer/hosts
+++ b/ansible-installer/hosts
@@ -1,0 +1,1 @@
+ip-172-31-17-63.eu-central-1.compute.internal

--- a/ansible-installer/hosts
+++ b/ansible-installer/hosts
@@ -1,1 +1,1 @@
-ip-172-31-17-63.eu-central-1.compute.internal
+localhost

--- a/ansible-installer/install_helical.yml
+++ b/ansible-installer/install_helical.yml
@@ -1,0 +1,82 @@
+- hosts: localhost
+  connection: local
+  gather_facts: False
+  vars_files:
+    - vars/vars.yml
+  tasks:
+  - name: Enable EPEL
+    yum:
+      name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+      state: present
+    become: yes
+  - name: Install prerequisites
+    yum:
+      name:
+        - maven
+        - java
+        - mariadb
+        - mariadb-server
+        - MySQL-python
+        - mysql-connector-python
+        - java-1.8.0-openjdk
+        - tomcat
+      state: present
+    become: yes
+  - name: Enable MariaDB service
+    service:
+      name: mariadb
+      state: started
+      enabed: true
+    become: yes
+  - name: Update mysql root password for all root accounts
+    mysql_user:
+      name: root
+      host: "{{ item }}"
+      password: "{{ mysql_root_password }}"
+      login_user: root
+      login_password: "{{ mysql_root_password }}"
+      check_implicit_admin: yes
+      priv: "*.*:ALL,GRANT"
+    with_items:
+      - "{{ ansible_hostname }}"
+      - 127.0.0.1
+      - ::1
+      - localhost
+    become: yes
+  - name: Copy the root credentials as .my.cnf file
+    template:
+      src: root.cnf.j2
+      dest: ~/.my.cnf
+      mode: 0600
+  - name: Create the Helical database user
+    mysql_user:
+      name: '{{ database_user }}'
+      password: '{{ database_password }}'
+      priv: '*.*:ALL'
+      state: present
+  - name: Clone the helical repo
+    git:
+      repo: '{{ helical_repo_url }}'
+      dest: '{{ repo_install_dir }}'
+      clone: yes
+      update: yes
+  - name: Create Helical database from dump
+    mysql_db:
+      name: '{{ database_name }}'
+      target: '{{ install_dir }}/db-dump/db.sql'
+      state: import
+      login_user: root
+      login_password: '{{ mysql_root_password }}'
+    become: yes
+  - name: Import sample report to Helical database
+    mysql_db:
+      name: '{{ database_name }}'
+      target: '{{ install_dir }}/db-dump/SampleData.sql'
+      state: import
+      login_user: root
+      login_password: '{{ mysql_root_password }}'
+    become: yes
+#  - name: Set Helical repository path
+#    lineinfile:
+#      path: '{{ install_Dir }}/hi-repository/System/Admin/setting.xml'
+      

--- a/ansible-installer/templates/root.cnf.j2
+++ b/ansible-installer/templates/root.cnf.j2
@@ -1,0 +1,3 @@
+[client]
+user=root
+password={{ mysql_root_pass }}

--- a/ansible-installer/vars/vars.yml
+++ b/ansible-installer/vars/vars.yml
@@ -1,0 +1,1 @@
+# Installation settings defined here


### PR DESCRIPTION
I'm going through the installation on Red Hat Enterprise Linux 7 and I'm creating pull requests as I go, pointing out things I found confusing or what would have made life easier for me.

If people can can see what the default db users is called, they can more easy prep the access to the database.