### PR TITLE
Automated installer based on Ansible

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To build Helical Insight Community Edition project you need
 *  Apache tomcat 7 or 8 should be installed.
 *  Use Mysql 5.7 or higher version.
 
- `NOTE: In case database is not accessed remotely then grant all priviledges to user.`
+ `NOTE: In case database is not accessed remotely then grant all priviledges to user (default called hiuser).`
 
 *  Database with name `hice` to be created in Mysql.
 

--- a/ansible-installer/README.md
+++ b/ansible-installer/README.md
@@ -1,0 +1,27 @@
+The automated Ansible installer works to simplify the installation of Helical Insight to a few commands.
+
+# Limitations
+The installer currently support Red Hat Enterprise Linux. Please feel free to contribute more operating systems.
+
+# 1. Prerequisites
+To put in place the installers prerequisites, as root, run below commands:
+```
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y install python-pip git
+pip install ansible
+```
+
+# 3. Download Helical Insigh github repository and configuring settings
+Run below commands to down the Helical Insight repository.
+```
+git clone https://github.com/helicalinsight/helicalinsight
+```
+Next, edit helicalinsight/ansible-installer/vars/vars.yml with correct values.
+
+# 3. Run the installer
+Run the installer as root, or a normal user with sudo access, as follows:
+
+```
+cd /path/to/helicalinsight/ansible-installer
+ansible-playbook -i hosts install_helical.yml
+```

--- a/ansible-installer/README.md
+++ b/ansible-installer/README.md
@@ -1,7 +1,8 @@
 The automated Ansible installer works to simplify the installation of Helical Insight to a few commands.
 
 # Limitations
-The installer currently support Red Hat Enterprise Linux. Please feel free to contribute more operating systems.
+* Tomcat needs access to the installation directory
+* The installer currently support Red Hat Enterprise Linux. Please feel free to contribute more operating systems.
 
 # 1. Prerequisites
 To put in place the installers prerequisites, as root, run below commands:

--- a/ansible-installer/hosts
+++ b/ansible-installer/hosts
@@ -1,0 +1,1 @@
+ip-172-31-17-63.eu-central-1.compute.internal

--- a/ansible-installer/hosts
+++ b/ansible-installer/hosts
@@ -1,1 +1,1 @@
-ip-172-31-17-63.eu-central-1.compute.internal
+localhost

--- a/ansible-installer/install_helical.yml
+++ b/ansible-installer/install_helical.yml
@@ -95,6 +95,8 @@
       src: '{{ install_dir }}/hi-ce/target/hi-ce.war'
       dest: /var/lib/tomcat/webapps/hi-ce.war
       mode: 0755
+      owner: tomcat
+      group: tomcat
   - name: Restart tomcat
     service:
       name: tomcat

--- a/ansible-installer/install_helical.yml
+++ b/ansible-installer/install_helical.yml
@@ -53,6 +53,7 @@
       password: '{{ database_password }}'
       priv: '*.*:ALL'
       state: present
+    become: yes
 #  - name: Clone the helical repo
 #    git:
 #      repo: '{{ helical_repo_url }}'
@@ -90,6 +91,20 @@
       path: '{{ install_dir }}/hi-repository/System/Admin/globalConnections.xml'
       xpath: /connections/tomcatJdbcDataSource/url
       value: '{{ helical_db_source }}'
+  - name: Fix pom.xml (HikariCP version number) for maven build
+    replace:
+      path: '{{ install_dir }}/pom.xml'
+      regexp: '2.4.7-hi'
+      replace: 2.7.4
+  - name: Maven install
+    command: 'mvn install:install-file -Dfile={{ install_dir }}/resources/tomcat-jdbc-7.0.65.jar -DgroupId=org.apache.tomcat -DartifactId=tomcat-jdbc -Dversion=7.0.65 -Dpackaging=jar'
+    become: yes
+  - name: Maven build dev
+    shell: 'cd {{ install_dir }} && mvn clean package -Denv=dev'
+    become: yes
+  - name: Maven build prod
+    shell: 'cd {{ install_dir }} && mvn clean package -Denv=production'
+    become: yes
   - name: Deploy hi-ce war file
     copy:
       src: '{{ install_dir }}/hi-ce/target/hi-ce.war'
@@ -97,37 +112,43 @@
       mode: 0755
       owner: tomcat
       group: tomcat
+    become: yes
   - name: Restart tomcat
     service:
       name: tomcat
       state: restarted
+    become: yes
   - name: Configure project properties with correct path
     replace:
-      path: /usr/share/tomcat/webapps/hi-ce/WEB-INF/classes/project.properties
+      path: /var/lib/tomcat/webapps/hi-ce/WEB-INF/classes/project.properties
       regexp: 'E:/New folder'
       replace: '{{ install_dir }}'
+    become: yes
   - name: Configure logging
     replace:
       path: /var/lib/tomcat/webapps/hi-ce/WEB-INF/classes/log4j.properties
       regexp: 'E:/New folder/helicalinsight-master'
       replace: '{{ install_dir }}'
+    become: yes
   - name: Configure the database connection
     replace:
       path: /var/lib/tomcat/webapps/hi-ce/WEB-INF/classes/application-context.xml
       regexp: 'name="username" value="hiuser"'
       replace: 'name="username" value="{{ database_user }}"'
+    become: yes
   - name: Configure the database connection and Hibernate dialect
     replace:
       path: /var/lib/tomcat/webapps/hi-ce/WEB-INF/classes/application-context.xml
       regexp: 'name="password" value="hiuser"'
       replace: 'name="password" value="{{ database_password }}"'
+    become: yes
   - name: Restart tomcat
     service:
       name: tomcat
       state: restarted
+    become: yes
   - name: Print BaseURL
     debug:
       msg: "Helical Insights will be reachable at: http://{{ helical_hostname }}:8080/hi-ce/hi.html"
-
 
 

--- a/ansible-installer/install_helical.yml
+++ b/ansible-installer/install_helical.yml
@@ -1,0 +1,82 @@
+- hosts: localhost
+  connection: local
+  gather_facts: False
+  vars_files:
+    - vars/vars.yml
+  tasks:
+  - name: Enable EPEL
+    yum:
+      name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+      state: present
+    become: yes
+  - name: Install prerequisites
+    yum:
+      name:
+        - maven
+        - java
+        - mariadb
+        - mariadb-server
+        - MySQL-python
+        - mysql-connector-python
+        - java-1.8.0-openjdk
+        - tomcat
+      state: present
+    become: yes
+  - name: Enable MariaDB service
+    service:
+      name: mariadb
+      state: started
+      enabed: true
+    become: yes
+  - name: Update mysql root password for all root accounts
+    mysql_user:
+      name: root
+      host: "{{ item }}"
+      password: "{{ mysql_root_password }}"
+      login_user: root
+      login_password: "{{ mysql_root_password }}"
+      check_implicit_admin: yes
+      priv: "*.*:ALL,GRANT"
+    with_items:
+      - "{{ ansible_hostname }}"
+      - 127.0.0.1
+      - ::1
+      - localhost
+    become: yes
+  - name: Copy the root credentials as .my.cnf file
+    template:
+      src: root.cnf.j2
+      dest: ~/.my.cnf
+      mode: 0600
+  - name: Create the Helical database user
+    mysql_user:
+      name: '{{ database_user }}'
+      password: '{{ database_password }}'
+      priv: '*.*:ALL'
+      state: present
+  - name: Clone the helical repo
+    git:
+      repo: '{{ helical_repo_url }}'
+      dest: '{{ repo_install_dir }}'
+      clone: yes
+      update: yes
+  - name: Create Helical database from dump
+    mysql_db:
+      name: '{{ database_name }}'
+      target: '{{ install_dir }}/db-dump/db.sql'
+      state: import
+      login_user: root
+      login_password: '{{ mysql_root_password }}'
+    become: yes
+  - name: Import sample report to Helical database
+    mysql_db:
+      name: '{{ database_name }}'
+      target: '{{ install_dir }}/db-dump/SampleData.sql'
+      state: import
+      login_user: root
+      login_password: '{{ mysql_root_password }}'
+    become: yes
+#  - name: Set Helical repository path
+#    lineinfile:
+#      path: '{{ install_Dir }}/hi-repository/System/Admin/setting.xml'
+      

--- a/ansible-installer/install_helical.yml
+++ b/ansible-installer/install_helical.yml
@@ -9,74 +9,123 @@
       name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
       state: present
     become: yes
-  - name: Install prerequisites
-    yum:
-      name:
-        - maven
-        - java
-        - mariadb
-        - mariadb-server
-        - MySQL-python
-        - mysql-connector-python
-        - java-1.8.0-openjdk
-        - tomcat
+  - name: Register to RHN and auto-subscribe to available content.
+    redhat_subscription:
       state: present
+      username: '{{ rhn_user }}'
+      password: '{{ rhn_password }}'
+      auto_attach: true
     become: yes
+  - name: Enable RHSM repositories (extras, optional)
+    rhsm_repository:
+      name: '{{ item }}'
+      state: enabled
+    with_items:
+      - rhel-7-server-extras-rpms
+      - rhel-7-server-optional-rpms
+    become: yes
+  # Troubleshoot yum module and then remove command module usage after solution found to slowness
+  - name: Install prerequisites
+    command: yum -y install maven java mariadb mariadb-server MySQL-python mysql-connector-python java-1.8.0-openjdk tomcat
+    become: yes
+#  - name: Install prerequisites
+#    yum:
+#      name:
+#        - maven
+#        - java
+#        - mariadb
+#        - mariadb-server
+#        - MySQL-python
+#        - mysql-connector-python
+#        - java-1.8.0-openjdk
+#        - tomcat
+#      state: present
+#    become: yes
   - name: Enable MariaDB service
     service:
       name: mariadb
       state: started
-      enabed: true
+      enabled: true
     become: yes
-  - name: Update mysql root password for all root accounts
-    mysql_user:
-      name: root
-      host: "{{ item }}"
-      password: "{{ mysql_root_password }}"
-      login_user: root
-      login_password: "{{ mysql_root_password }}"
-      check_implicit_admin: yes
-      priv: "*.*:ALL,GRANT"
-    with_items:
-      - "{{ ansible_hostname }}"
-      - 127.0.0.1
-      - ::1
-      - localhost
-    become: yes
-  - name: Copy the root credentials as .my.cnf file
-    template:
-      src: root.cnf.j2
-      dest: ~/.my.cnf
-      mode: 0600
   - name: Create the Helical database user
     mysql_user:
       name: '{{ database_user }}'
       password: '{{ database_password }}'
       priv: '*.*:ALL'
       state: present
-  - name: Clone the helical repo
-    git:
-      repo: '{{ helical_repo_url }}'
-      dest: '{{ repo_install_dir }}'
-      clone: yes
-      update: yes
-  - name: Create Helical database from dump
-    mysql_db:
-      name: '{{ database_name }}'
-      target: '{{ install_dir }}/db-dump/db.sql'
-      state: import
-      login_user: root
-      login_password: '{{ mysql_root_password }}'
-    become: yes
+#  - name: Clone the helical repo
+#    git:
+#      repo: '{{ helical_repo_url }}'
+#      dest: '{{ repo_install_dir }}'
+#      clone: yes
+#      update: yes
   - name: Import sample report to Helical database
     mysql_db:
       name: '{{ database_name }}'
-      target: '{{ install_dir }}/db-dump/SampleData.sql'
+      target: '{{ install_dir }}/db-dump/SampleTravelData.sql'
       state: import
-      login_user: root
-      login_password: '{{ mysql_root_password }}'
     become: yes
-#  - name: Set Helical repository path
-#    lineinfile:
-#      path: '{{ install_Dir }}/hi-repository/System/Admin/setting.xml'
-      
+  - name: Set hi-repository path
+    xml:
+      path: '{{ install_dir }}/hi-repository/System/Admin/setting.xml'
+      xpath: /efwProject/efwSolution
+      value: '{{ install_dir }}/hi-repository'
+  - name: Set BaseURL to listen to
+    xml:
+      path: '{{ install_dir }}/hi-repository/System/Admin/setting.xml'
+      xpath: /efwProject/BaseUrl
+      value: 'http://{{ helical_hostname }}:8080/hi-ce/hi.html'
+  - name: Configure app with correct helical database user
+    xml:
+      path: '{{ install_dir }}/hi-repository/System/Admin/globalConnections.xml'
+      xpath: /connections/tomcatJdbcDataSource/username
+      value: '{{ database_user }}'
+  - name: Configure app with correct helical database password
+    xml:
+      path: '{{ install_dir }}/hi-repository/System/Admin/globalConnections.xml'
+      xpath: /connections/tomcatJdbcDataSource/password
+      value: '{{ database_password }}'
+  - name: Configure app with correct helical database source
+    xml:
+      path: '{{ install_dir }}/hi-repository/System/Admin/globalConnections.xml'
+      xpath: /connections/tomcatJdbcDataSource/url
+      value: '{{ helical_db_source }}'
+  - name: Deploy hi-ce war file
+    copy:
+      src: '{{ install_dir }}/hi-ce/target/hi-ce.war'
+      dest: /var/lib/tomcat/webapps/hi-ce.war
+      mode: 0755
+  - name: Restart tomcat
+    service:
+      name: tomcat
+      state: restarted
+  - name: Configure project properties with correct path
+    replace:
+      path: /usr/share/tomcat/webapps/hi-ce/WEB-INF/classes/project.properties
+      regexp: 'E:/New folder'
+      replace: '{{ install_dir }}'
+  - name: Configure logging
+    replace:
+      path: /var/lib/tomcat/webapps/hi-ce/WEB-INF/classes/log4j.properties
+      regexp: 'E:/New folder/helicalinsight-master'
+      replace: '{{ install_dir }}'
+  - name: Configure the database connection
+    replace:
+      path: /var/lib/tomcat/webapps/hi-ce/WEB-INF/classes/application-context.xml
+      regexp: 'name="username" value="hiuser"'
+      replace: 'name="username" value="{{ database_user }}"'
+  - name: Configure the database connection and Hibernate dialect
+    replace:
+      path: /var/lib/tomcat/webapps/hi-ce/WEB-INF/classes/application-context.xml
+      regexp: 'name="password" value="hiuser"'
+      replace: 'name="password" value="{{ database_password }}"'
+  - name: Restart tomcat
+    service:
+      name: tomcat
+      state: restarted
+  - name: Print BaseURL
+    debug:
+      msg: "Helical Insights will be reachable at: http://{{ helical_hostname }}:8080/hi-ce/hi.html"
+
+
+

--- a/ansible-installer/install_helical.yml
+++ b/ansible-installer/install_helical.yml
@@ -121,7 +121,7 @@
   - name: Configure project properties with correct path
     replace:
       path: /var/lib/tomcat/webapps/hi-ce/WEB-INF/classes/project.properties
-      regexp: 'E:/New folder'
+      regexp: 'E:/helicalinsight'
       replace: '{{ install_dir }}'
     become: yes
   - name: Configure logging

--- a/ansible-installer/templates/root.cnf.j2
+++ b/ansible-installer/templates/root.cnf.j2
@@ -1,0 +1,3 @@
+[client]
+user=root
+password={{ mysql_root_pass }}

--- a/ansible-installer/vars/vars.yml
+++ b/ansible-installer/vars/vars.yml
@@ -1,1 +1,16 @@
 # Installation settings defined here
+rhn_user: rhn-username
+rhn_password: rhn-password
+
+helical_hostname: ip-or-dns-name
+
+database_password: hipass
+repo_install_dir: /root
+install_dir: /home/myuser/helicalinsight
+helical_repo_url: https://github.com/mglantz/helicalinsight
+helical_db_source: jdbc:mysql://localhost:3306/SampleTravelData
+
+# Do note change below
+database_user: hiuser
+mysql_root_password: hiroot
+database_name: hice

--- a/ansible-installer/vars/vars.yml
+++ b/ansible-installer/vars/vars.yml
@@ -1,0 +1,1 @@
+# Installation settings defined here

--- a/ansible-installer/vars/vars.yml
+++ b/ansible-installer/vars/vars.yml
@@ -1,16 +1,24 @@
+#
 # Installation settings defined here
+#
+
+# Red Hat Network credentials 
 rhn_user: rhn-username
 rhn_password: rhn-password
 
+# Hostname which app is accessed via
 helical_hostname: ip-or-dns-name
 
+# Password for database user
 database_password: hipass
-repo_install_dir: /root
+
+# Installation directory
 install_dir: /home/myuser/helicalinsight
-helical_repo_url: https://github.com/mglantz/helicalinsight
+
+# DB source, do not change this if you don't know what it is
 helical_db_source: jdbc:mysql://localhost:3306/SampleTravelData
 
-# Do note change below
+# Don't change if you don't know what you are doing, hardcoded values
 database_user: hiuser
 mysql_root_password: hiroot
 database_name: hice


### PR DESCRIPTION
Hi there,

I found that installing Helical Insight on Linux was a bit troublesome, a lot of manual editing of files in combination with a difficult to follow installation instructions. So, I created this automated installer for Helical Insight on Red Hat Enterprise Linux.

As a result, you get a simple yaml file with 'key: value' settings, which configures how to setup the application.

Please checkout the README.md file for detailed instructions.

Ansible, which the installer is written in, supports any operating system, so adding more operating systems, such as Windows, should be fairly simple. 

