### PR TITLE
feat(instant-bi): add bounded SQL self-correction loop to NL->SQL flow

### DIFF
--- a/ib/helicalbi/bl/interactive.py
+++ b/ib/helicalbi/bl/interactive.py
@@ -237,7 +237,7 @@ def register(flask_app) -> None:
 
             ensure_not_aborted(request_id)
             logger.debug("Executing SQL for thread=%s", thread_id)
-            result = SqlExecutor().process_flow(result)
+            result = SqlExecutor().process_flow(result, request_id=request_id)
             ensure_not_aborted(request_id)
             logger.debug("Invoking visualization graph for thread=%s", thread_id)
             result = app().viz_graph.invoke(result, config)

--- a/ib/helicalbi/helicalbi/common/app_config.py
+++ b/ib/helicalbi/helicalbi/common/app_config.py
@@ -144,6 +144,7 @@ def __getattr__(name: str):  # noqa: N807
         "api_cache_max_entries": lambda: max(1, int(_api_cache().get("max_entries", 100))),
         # sql
         "default_sql_limit":     lambda: int(_raw.get("sql", {}).get("default_limit", 100)),
+        "sql_repair_max_attempts": lambda: max(0, int(_raw.get("sql", {}).get("repair_max_attempts", 1))),
         # kpi
         "kpi_suggestion_query":  lambda: str(
             _kpi().get("suggestion_query", "Suggest few Measurable and timebound KPIS")

--- a/ib/helicalbi/helicalbi/config/application_config.yaml
+++ b/ib/helicalbi/helicalbi/config/application_config.yaml
@@ -26,6 +26,7 @@ api_cache:
 
 sql:
   default_limit: 100        # Default row limit appended to generated SQL queries
+  repair_max_attempts: 1    # Max automatic self-correction retries when generated SQL fails to execute (0 disables)
 
 kpi:
   suggestion_query: "Suggest few Measurable and timebound KPIS"  # Default KPI suggestion prompt; overridden by model JSON "suggestion_query" when present

--- a/ib/helicalbi/helicalbi/core/flows/SqlExecutor.py
+++ b/ib/helicalbi/helicalbi/core/flows/SqlExecutor.py
@@ -2,35 +2,46 @@ import json
 import logging
 
 from helicalbi.api.QueryExecutor import execute_query
-from helicalbi.common.ChatManager import add_insight, get_last_insight
+from helicalbi.common import app_config
+from helicalbi.common.ChatManager import add_insight
 from helicalbi.common.LlmInvokeHelper import invoke_llm
 from helicalbi.common.configuration import llm
 from helicalbi.model.ModelState import ModelState
 from helicalbi.prompt.ErrorPrompt import error_prompt_formatted
+from helicalbi.prompt.SqlRepairPrompt import sql_repair_prompt
 from helicalbi.prompt.SqlSuccessPrompty import success_prompt_formatted
+from helicalbi.sql.SqlSanitizer import extract_sql
 
 logger = logging.getLogger(__name__)
 
 
 class SqlExecutor:
 
-
-    def process_flow(self, state: ModelState):
+    def process_flow(self, state: ModelState, request_id=None):
         logger.info("SqlExecutor flow started")
         state["sql_result"] = "Not Generated"
         state["sql_error"] = "Not Generated"
         if state.get("skip"):
             return state
         intent = state.get("intent", "")
-        if "EXEC" not in intent:
+        if "EXEC" in intent:
+            return state
+
+        required_tables = state.get("required_tables", [])
+        domain = state.get("domain", [])
+        topics = state.get("topics", [])
+        metadata_to_send = {
+            "required_tables": required_tables,
+            "domain": domain,
+            "topics": topics,
+        }
+
+        user_query = state["query"]
+        max_repair_attempts = app_config.sql_repair_max_attempts
+        attempt = 0
+
+        while True:
             sql = state.get("sql", "")
-            required_tables = state.get("required_tables",[])
-            domain = state.get("domain",[])
-            topics = state.get("topics",[])
-            metadata_to_send={}
-            metadata_to_send["required_tables"]=required_tables
-            metadata_to_send["domain"]=domain
-            metadata_to_send["topics"]=topics
 
             try:
                 api_response = execute_query(
@@ -54,50 +65,116 @@ class SqlExecutor:
 
             status = api_response['status']
             response_string = api_response['response']
-            user_query = state["query"]
 
-            prev_responses = get_last_insight(state["thread_id"])
+            if status == 1:
+                if attempt:
+                    logger.info(
+                        "SQL succeeded after %d self-correction attempt(s)", attempt
+                    )
+                state["sql_error"] = "Not Generated"
+                state["sql_result"] = response_string
+                state["data"] = response_string["data"]
+                state["metadata"] = response_string["metadata"]
 
-            if status != 1:
-                logger.error(
-                    "SQL execution failed status=%s response=%s",
-                    status,
-                    response_string,
+                formatted_format = success_prompt_formatted.format(
+                    user_query=user_query,
+                    sql_query=sql,
+                    metadata=json.dumps(metadata_to_send, default=str),
                 )
-                state["sql_error"] = response_string
-                error_insight, _ = invoke_llm(
+                insight, _ = invoke_llm(
                     llm,
-                    error_prompt_formatted.format(
-                        response_string=response_string,
-                        user_query=user_query,
-                        username=state["user_name"],
-                    ),
+                    formatted_format,
                     state=state,
                 )
-                state["output"] = error_insight.content
-                add_insight(state["thread_id"], error_insight.content)
-                state["skip"] = True
-                state["metadata"] = []
-                state["data"] = []
+                state["output"] = insight.content
+                add_insight(state["thread_id"], insight.content)
                 return state
-                # raise Exception("Something went wrong")
-            # Here you'd call a real DB executor,
-            # but for now just simulate
-            state["sql_result"] = response_string
-            state["data"] = response_string["data"]
-            state["metadata"] = response_string["metadata"]
 
-            formatted_format = success_prompt_formatted.format(
-                user_query=user_query,
-                sql_query=sql,
-                metadata=json.dumps(metadata_to_send, default=str),
+            # status != 1 -> the database rejected the query.
+            logger.error(
+                "SQL execution failed status=%s response=%s",
+                status,
+                response_string,
             )
-            insight, _ = invoke_llm(
+            state["sql_error"] = response_string
+
+            if attempt < max_repair_attempts:
+                self._abort_check(request_id)
+                repaired_sql = self._repair_sql(state, sql, response_string)
+                if (
+                    repaired_sql
+                    and repaired_sql.strip()
+                    and repaired_sql.strip() != (sql or "").strip()
+                ):
+                    attempt += 1
+                    logger.info(
+                        "Attempting SQL self-correction %d/%d",
+                        attempt,
+                        max_repair_attempts,
+                    )
+                    state["sql"] = repaired_sql
+                    continue
+                logger.info(
+                    "SQL self-correction produced no usable change; giving up "
+                    "after %d attempt(s)",
+                    attempt,
+                )
+
+            # No repair attempts left (or repair unavailable): surface a calm,
+            # non-technical message to the user (unchanged behaviour).
+            error_insight, _ = invoke_llm(
                 llm,
-                formatted_format,
+                error_prompt_formatted.format(
+                    response_string=response_string,
+                    user_query=user_query,
+                    username=state["user_name"],
+                ),
                 state=state,
             )
-            state["output"] = insight.content
-            add_insight(state["thread_id"], insight.content)
+            state["output"] = error_insight.content
+            add_insight(state["thread_id"], error_insight.content)
+            state["skip"] = True
+            state["metadata"] = []
+            state["data"] = []
+            return state
 
-        return state
+    def _repair_sql(self, state: ModelState, failed_sql, db_error):
+        """Ask the model to fix ``failed_sql`` given the database ``db_error``.
+
+        Reuses the schema context already gathered during generation
+        (``required_details``), so a repair is a single cheap LLM call with no
+        re-retrieval. Returns the corrected SQL string, or ``None`` if the
+        repair call itself failed (the caller then falls back to the error
+        message path).
+        """
+        try:
+            allowed_context = json.dumps(
+                state.get("required_details", {}), default=str
+            )
+            prompt_text = sql_repair_prompt.format(
+                dialect=state.get("dialect", ""),
+                dbname=state.get("dbname", ""),
+                user_query=state.get("query", ""),
+                failed_sql=failed_sql or "",
+                db_error=str(db_error),
+                allowed_context=allowed_context,
+            )
+            ai_message, _ = invoke_llm(llm, prompt_text, state=state)
+            return extract_sql(ai_message.content, state.get("dialect"))
+        except Exception:
+            logger.exception("SQL self-correction attempt failed to produce a query")
+            return None
+
+    @staticmethod
+    def _abort_check(request_id):
+        """Cooperative cancellation check between self-correction attempts.
+
+        Imported lazily to avoid a module import cycle between the core flows
+        and the request-facing ``bl`` package. An abort raised here is allowed
+        to propagate so the loop stops immediately.
+        """
+        if not request_id:
+            return
+        from bl.helpers import ensure_not_aborted
+
+        ensure_not_aborted(request_id)

--- a/ib/helicalbi/helicalbi/prompt/SqlRepairPrompt.py
+++ b/ib/helicalbi/helicalbi/prompt/SqlRepairPrompt.py
@@ -1,0 +1,39 @@
+from langchain_core.prompts import PromptTemplate
+
+# Prompt used by the SQL self-correction loop. When a generated query fails to
+# execute against the database, the failing SQL and the exact database error are
+# fed back to the model together with the same allowed schema context that was
+# used to generate it, and a corrected read-only SELECT is requested.
+sql_repair_prompt_string = """
+You are an expert {dialect} SQL engineer fixing a query that FAILED to execute.
+
+The user asked:
+{user_query}
+
+The previous SQL that was generated is:
+{failed_sql}
+
+Executing it on the {dialect} database "{dbname}" returned this error:
+{db_error}
+
+You may ONLY use the tables, columns, joins and metrics listed here. Do not
+invent any new table or column:
+{allowed_context}
+
+Task:
+Return a corrected {dialect} SQL query that fixes the cause of the error and
+answers the user's question.
+
+Requirements:
+- Return ONLY the corrected SQL query. No explanation, no markdown fences, no commentary.
+- The statement MUST be a single read-only SELECT. Never emit INSERT, UPDATE,
+  DELETE, DROP, ALTER, TRUNCATE, MERGE, or multiple statements.
+- Use valid {dialect} syntax and only the tables/columns/joins/metrics provided above.
+- Address the specific problem indicated by the error, for example an unknown
+  column, an invalid join, a GROUP BY / aggregation mistake, or a dialect
+  specific function.
+- If the error cannot be fixed with the provided context, return the closest
+  valid SELECT you can using only the allowed context.
+"""
+
+sql_repair_prompt = PromptTemplate.from_template(sql_repair_prompt_string)

--- a/ib/helicalbi/tests/functional/test_sql_repair.py
+++ b/ib/helicalbi/tests/functional/test_sql_repair.py
@@ -1,0 +1,107 @@
+"""Tests for the SQL self-correction loop in ``SqlExecutor.process_flow``.
+
+When a generated query is rejected by the database, the executor feeds the
+error back to the model to regenerate a corrected query, up to
+``app_config.sql_repair_max_attempts`` times, before surfacing an error to the
+user. ``0`` preserves the original single-shot behaviour.
+"""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from helicalbi.core.flows.SqlExecutor import SqlExecutor
+
+pytestmark = pytest.mark.functional
+
+
+def _base_state():
+    return {
+        "query": "show me total sales by region",
+        "session_cookie": "cookie",
+        "md_location": "/loc",
+        "md_file_name": "model.metadata",
+        "sql": "SELECT bad_col FROM sales",
+        "thread_id": "t-1",
+        "user_name": "Darshan",
+        "intent": "NEW",
+        "required_tables": ["sales"],
+        "domain": ["sales"],
+        "topics": ["revenue"],
+        "dialect": "postgres",
+        "dbname": "warehouse",
+        "required_details": {"required_tables": ["sales"]},
+    }
+
+
+def _fake_insight(*_args, **_kwargs):
+    return SimpleNamespace(content="a friendly message"), None
+
+
+def _set_max_attempts(monkeypatch, value):
+    # Setting a real attribute shadows the module-level __getattr__ resolver.
+    monkeypatch.setattr(
+        "helicalbi.common.app_config.sql_repair_max_attempts", value, raising=False
+    )
+
+
+class TestSqlSelfCorrection:
+    def test_repairs_and_succeeds(self, monkeypatch):
+        _set_max_attempts(monkeypatch, 1)
+        responses = [
+            {"status": 0, "response": "ERROR: column bad_col does not exist"},
+            {"status": 1, "response": {"data": [{"total": 42}], "metadata": [{"rows": 1}]}},
+        ]
+        with patch("helicalbi.core.flows.SqlExecutor.execute_query", side_effect=responses) as exec_mock, \
+             patch("helicalbi.core.flows.SqlExecutor.invoke_llm", side_effect=_fake_insight), \
+             patch.object(SqlExecutor, "_repair_sql", return_value="SELECT SUM(amount) AS total FROM sales") as repair_mock:
+            state = SqlExecutor().process_flow(_base_state())
+
+        assert exec_mock.call_count == 2
+        assert repair_mock.call_count == 1
+        assert state["sql"] == "SELECT SUM(amount) AS total FROM sales"
+        assert state["data"] == [{"total": 42}]
+        assert state["sql_error"] == "Not Generated"
+        assert not state.get("skip")
+
+    def test_gives_up_after_max_attempts(self, monkeypatch):
+        _set_max_attempts(monkeypatch, 1)
+        with patch("helicalbi.core.flows.SqlExecutor.execute_query",
+                   return_value={"status": 0, "response": "ERROR: boom"}) as exec_mock, \
+             patch("helicalbi.core.flows.SqlExecutor.invoke_llm", side_effect=_fake_insight) as llm_mock, \
+             patch.object(SqlExecutor, "_repair_sql", return_value="SELECT still_wrong FROM sales") as repair_mock:
+            state = SqlExecutor().process_flow(_base_state())
+
+        # one initial execution + exactly one repair execution
+        assert exec_mock.call_count == 2
+        assert repair_mock.call_count == 1
+        assert state["skip"] is True
+        assert state["sql_error"] == "ERROR: boom"
+        assert state["output"] == "a friendly message"
+        # only the final user-facing error message is generated via invoke_llm here
+        assert llm_mock.call_count == 1
+
+    def test_disabled_when_zero(self, monkeypatch):
+        _set_max_attempts(monkeypatch, 0)
+        with patch("helicalbi.core.flows.SqlExecutor.execute_query",
+                   return_value={"status": 0, "response": "ERROR: boom"}) as exec_mock, \
+             patch("helicalbi.core.flows.SqlExecutor.invoke_llm", side_effect=_fake_insight), \
+             patch.object(SqlExecutor, "_repair_sql", return_value="SELECT anything") as repair_mock:
+            state = SqlExecutor().process_flow(_base_state())
+
+        assert exec_mock.call_count == 1
+        assert repair_mock.call_count == 0
+        assert state["skip"] is True
+
+    def test_success_first_try_does_not_repair(self, monkeypatch):
+        _set_max_attempts(monkeypatch, 2)
+        with patch("helicalbi.core.flows.SqlExecutor.execute_query",
+                   return_value={"status": 1, "response": {"data": [], "metadata": []}}) as exec_mock, \
+             patch("helicalbi.core.flows.SqlExecutor.invoke_llm", side_effect=_fake_insight), \
+             patch.object(SqlExecutor, "_repair_sql", return_value="SELECT 1") as repair_mock:
+            state = SqlExecutor().process_flow(_base_state())
+
+        assert exec_mock.call_count == 1
+        assert repair_mock.call_count == 0
+        assert state["sql_error"] == "Not Generated"
+        assert not state.get("skip")


### PR DESCRIPTION
When an AI-generated query is rejected by the database, feed the failing SQL and the exact database error back to the model to regenerate a corrected read-only SELECT, retrying up to `sql.repair_max_attempts` times before surfacing an error to the user. The repair reuses the schema context already gathered during generation, so it is a single cheap LLM call with no re-retrieval.

- New SqlRepairPrompt; repair loop in SqlExecutor.process_flow
- Config knob sql.repair_max_attempts (default 1; 0 preserves prior behaviour)
- Cooperative abort check between attempts; token/time cost is accounted
- Tests: repair-then-succeed, give-up-after-max, disabled, success-first-try

## Summary

<!-- What does this PR change, and why? Keep it to 1–3 short bullets. -->

-
-
-

## Related issue

<!-- Link the GitHub issue (preferred) or Bugzilla ID if applicable. -->

- Closes #
- Bugzilla (if any):

## Type of change

- [x] Bug fix
- [x] New feature / enhancement
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / CI / Docker / scripts
- [ ] Other (describe below)

## Area

- [ ] Backend (`server/`)
- [ ] Frontend (`client/`)
- [x] Instant BI (`ib/`)
- [ ] Docker / deployment
- [ ] Docs / contributing

## How was this tested?

<!-- Check what applies and note commands or scenarios you ran. -->

- [ ] Backend tests (`mvn test`)
- [ ] Frontend tests (`npm test`)
- [x] Instant BI tests (`pytest`)
- [ ] Manual test (describe steps below)
- [ ] Not applicable (docs-only / config-only)

**Manual test steps / notes:**

1.
2.
3.

## Checklist

- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md) (fork → branch → PR)
- [x] Changes are focused on one concern
- [x] No secrets, `.env`, license files, or machine-specific paths are committed
- [ ] Docs updated if behavior or setup changed
- [x] CI is expected to pass for this change

## Screenshots / logs (if UI or error-related)

<!-- Paste screenshots or key log lines here. -->
