### PR TITLE
Add MongoDB database connectivity support

### DIFF
--- a/MongoDB-Integration-README.md
+++ b/MongoDB-Integration-README.md
@@ -1,0 +1,79 @@
+# MongoDB Support for Helical Insight
+
+## What this does
+
+Adds MongoDB as a database connection option, using the same JDBC-based
+pipeline every other database in Helical Insight already uses (MySQL,
+Postgres, etc.) instead of building a separate path just for Mongo.
+
+The repo already had a half-finished hook for this in
+`MongoConnectionFactory.java` — it recognized a Mongo driver name but always
+returned a connection that was `null`. This fills that in with a real
+connection.
+
+## Driver used
+
+`org.mongodb:mongodb-jdbc` v3.0.3 — MongoDB's own official JDBC driver,
+Apache 2.0 licensed, free on Maven Central. Driver class:
+`com.mongodb.jdbc.MongoDriver`.
+
+One thing worth flagging: this driver talks to **MongoDB Atlas SQL**, not a
+plain self-hosted `mongod`. For a fully local Mongo setup you'd need a
+different driver — didn't have time to validate that path in the 24 hours.
+
+Also worth noting — the codebase already had references to two *other*
+Mongo driver names (`mongodb.jdbc.MongoDriver` and a proprietary
+`com.helical.mongodb.MongoJdbcDriver`), but neither had an actual dependency
+behind them. Went with the real MongoDB driver instead and kept backward
+compatibility with the old driver name in code, just in case.
+
+## Files changed
+
+* `server/core/pom.xml` — added the mongodb-jdbc dependency (+ junit for
+the test)
+* `server/core/src/main/java/com/helicalinsight/datasource/MongoConnectionFactory.java` —
+replaced the null-connection placeholder with a real `DriverManager`
+connection, reading `jdbcUrl` / `userName` / `password` the same way the
+rest of the app does
+* `server/core/src/test/java/com/helicalinsight/datasource/MongoConnectionFactoryTest.java` —
+small unit test, confirms the driver loads
+* Three properties files under `hi-repository` (`databaseDrivers.properties`,
+`sqlDialects.properties`, `driverDefaultQuery.properties`) — added the
+same default-URL / dialect / test-query entries every other DB has, so
+Mongo behaves like a first-class connection type
+
+Nothing else was touched. The normal JDBC path for other databases is
+untouched — the Mongo logic only kicks in when the driver name matches.
+
+## How to set up a connection
+
+Same connection JSON shape as any other JDBC data source:
+
+```json
+{
+  "connectionJson": {
+    "driverClassName": "com.mongodb.jdbc.MongoDriver",
+    "jdbcUrl": "jdbc:mongodb://<HOST>:27017/<DATABASE>",
+    "userName": "<MONGO\_USERNAME>",
+    "password": "<MONGO\_PASSWORD>"
+  }
+}
+```
+
+## Testing
+
+* `mvn clean compile` — builds fine
+* Full app build from source via `docker compose -f docker-compose.dev.yml up --build` —
+starts up clean
+* Unit test passes (driver loads on classpath)
+* Logged into the running app, clicked around, checked logs — no errors tied
+to the Mongo changes. Only pre-existing, unrelated error is an SMTP
+connection failure (no mail server configured locally, not related to this
+work)
+* Didn't get a chance to test against a real live MongoDB Atlas instance
+within the time window — connection logic is verified to compile, load
+the driver correctly, and fail cleanly (via `ConnectionException`) when
+given a bad host, but not verified against a real successful connection
+
+## 
+

--- a/server/core/pom.xml
+++ b/server/core/pom.xml
@@ -39,4 +39,12 @@
             </plugin>
         </plugins>
     </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-jdbc</artifactId>
+            <version>3.0.3</version>
+        </dependency>
+        
+    </dependencies>
 </project>

--- a/server/core/src/main/java/com/helicalinsight/datasource/MongoConnectionFactory.java
+++ b/server/core/src/main/java/com/helicalinsight/datasource/MongoConnectionFactory.java
@@ -67,12 +67,52 @@ public class MongoConnectionFactory extends DatabaseConnectionFactory {
 				driverClassName = connectionDetails.get("driverName").getAsString();
 			}
 
-			if ("mongodb.jdbc.MongoDriver".equalsIgnoreCase(driverClassName)) {
-				DriverConnection driverConnection = new DriverConnection();
-				driverConnection.setConnection(null);
-				driverConnection.setDriverClass("mongodb.jdbc.MongoDriver");
-				return driverConnection;
+						if ("mongodb.jdbc.MongoDriver".equalsIgnoreCase(driverClassName)
+					|| "com.mongodb.jdbc.MongoDriver".equalsIgnoreCase(driverClassName)) {
 
+				String jdbcUrl = null;
+				String userName = null;
+				String password = null;
+
+				if (connectionDetails.has("jdbcUrl")) {
+					jdbcUrl = connectionDetails.get("jdbcUrl").getAsString();
+				} else if (connectionDetails.has("url")) {
+					jdbcUrl = connectionDetails.get("url").getAsString();
+				}
+				if (connectionDetails.has("userName")) {
+					userName = connectionDetails.get("userName").getAsString();
+				} else if (connectionDetails.has("username")) {
+					userName = connectionDetails.get("username").getAsString();
+				}
+				if (connectionDetails.has("password")) {
+					password = connectionDetails.get("password").getAsString();
+				}
+
+				DriverConnection driverConnection = new DriverConnection();
+				driverConnection.setDriverClass("com.mongodb.jdbc.MongoDriver");
+
+				try {
+					Class.forName("com.mongodb.jdbc.MongoDriver");
+
+					java.sql.Connection mongoConnection;
+					if (userName != null && !userName.isEmpty()) {
+						java.util.Properties props = new java.util.Properties();
+						props.setProperty("user", userName);
+						props.setProperty("password", password != null ? password : "");
+						mongoConnection = java.sql.DriverManager.getConnection(jdbcUrl, props);
+					} else {
+						mongoConnection = java.sql.DriverManager.getConnection(jdbcUrl);
+					}
+
+					driverConnection.setConnection(mongoConnection);
+				} catch (ClassNotFoundException e) {
+					throw new ConnectionException(
+							"MongoDB JDBC driver class not found: com.mongodb.jdbc.MongoDriver - " + e.getMessage());
+				} catch (java.sql.SQLException e) {
+					throw new ConnectionException("Failed to connect to MongoDB: " + e.getMessage());
+				}
+
+				return driverConnection;
 			}
 			if (driverClassName != null && driverClassName.startsWith(JsonUtils.getHiMiddleWareName())) {
 				formJson.addProperty("id", "-1");

--- a/server/core/src/test/java/com/helicalinsight/datasource/MongoConnectionFactoryTest.java
+++ b/server/core/src/test/java/com/helicalinsight/datasource/MongoConnectionFactoryTest.java
@@ -1,0 +1,15 @@
+package com.helicalinsight.datasource;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MongoConnectionFactoryTest {
+
+    @Test
+    void mongoDriverClassShouldBeLoadable() {
+        assertDoesNotThrow(() -> {
+            Class.forName("com.mongodb.jdbc.MongoDriver");
+        }, "MongoDB JDBC driver class should be on the classpath");
+    }
+
+}

--- a/server/hi-repository/System/Admin/databaseDrivers.properties
+++ b/server/hi-repository/System/Admin/databaseDrivers.properties
@@ -3,6 +3,7 @@
 #data source/connection creation using the UI. The default values are configured for well known
 #databases.
 #hive
+com.mongodb.jdbc.MongoDriver=jdbc:mongodb://{{hostName}}:{{port}}/{{database}},27017
 org.apache.hive.jdbc.HiveDriver=jdbc:hive2://{{hostName}}:{{port}}/{{database}},10001
 
 #Apache Drill

--- a/server/hi-repository/System/Admin/driverDefaultQuery.properties
+++ b/server/hi-repository/System/Admin/driverDefaultQuery.properties
@@ -1,4 +1,4 @@
-
+com.mongodb.jdbc.MongoDriver=SELECT 1
 #Oracle
 oracle.jdbc.OracleDriver=SELECT 1 FROM DUAL
 oracle.jdbc.driver.OracleDriver=SELECT 1 FROM DUAL

--- a/server/hi-repository/System/Admin/sqlDialects.properties
+++ b/server/hi-repository/System/Admin/sqlDialects.properties
@@ -1,4 +1,5 @@
 
+com.mongodb.jdbc.MongoDriver=mongo
 #Oracle
 oracle.jdbc.OracleDriver=org.hibernate.dialect.OracleDialect
 


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? Keep it to 1–3 short bullets. -->

-Adds MongoDB as a database connection option, using the same JDBC-based pipeline every other database in Helical Insight already uses (MySQL, Postgres, etc.) instead of building a separate path just for Mongo.
-The repo already had a half-finished hook for this in `MongoConnectionFactory.java` — it recognized a Mongo driver name but always returned a connection that was `null`. This fills that in with a real connection.
-

## Related issue

<!-- Link the GitHub issue (preferred) or Bugzilla ID if applicable. -->

- Closes #
- Bugzilla (if any):

## Type of change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / CI / Docker / scripts
- [ ] Other (describe below)

## Area

- [x] Backend (`server/`)
- [ ] Frontend (`client/`)
- [ ] Instant BI (`instantbi/`)
- [ ] Docker / deployment
- [ ] Docs / contributing

## How was this tested?

<!-- Check what applies and note commands or scenarios you ran. -->

- [ ] Backend tests (`mvn test`)
- [ ] Frontend tests (`npm test`)
- [ ] Instant BI tests (`pytest`)
- [x] Manual test (describe steps below)
- [ ] Not applicable (docs-only / config-only)

**Manual test steps / notes:**

1.Ran `mvn clean compile -f core/pom.xml` — confirms the mongodb-jdbc dependency resolves and the code compiles cleanly.
2.Ran the unit test `MongoConnectionFactoryTest` (`mvn test -f core/pom.xml-Dtest=MongoConnectionFactoryTest`) — confirms the MongoDB JDBC driver class loads correctly on the classpath.
3.Built and ran the full application from source via `docker compose -f docker-compose.dev.yml up --build`, logged in as
   hiadmin, and checked application logs — confirmed the app starts and runs normally with no errors related to the               MongoDB changes. Existing JDBC connection logic for other databases was not modified.

## Checklist

- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md) (fork → branch → PR)
- [x] Changes are focused on one concern
- [x] No secrets, `.env`, license files, or machine-specific paths are committed
- [ ] Docs updated if behavior or setup changed
- [x] CI is expected to pass for this change

## Screenshots / logs (if UI or error-related)

<!-- Paste screenshots or key log lines here. -->
